### PR TITLE
Require Cabal-version 1.8

### DIFF
--- a/zenc.cabal
+++ b/zenc.cabal
@@ -10,7 +10,7 @@ Maintainer:          dagitj@gmail.com
 Copyright:           GHC HQ
 Category:            Text
 Build-type:          Simple
-Cabal-version:       >=1.6
+Cabal-version:       >=1.8
 
 
 Library


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: zenc.cabal:21:36: version operators used. To use version operators
the package needs to specify at least 'cabal-version: >= 1.8'.
```